### PR TITLE
Fix incompatible charset & collation and change it to utf8mb4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "symfony/framework-bundle": "~4.3",
+        "symfony/framework-bundle": "^3.0|^4.0",
         "doctrine/orm": "~2.6",
         "dragonmantank/cron-expression": "~2.0"
     },

--- a/src/DependencyInjection/GloobyTaskExtension.php
+++ b/src/DependencyInjection/GloobyTaskExtension.php
@@ -19,9 +19,6 @@ class GloobyTaskExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
-
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/Entity/QueuedTask.php
+++ b/src/Entity/QueuedTask.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Table(
  *   name="task_queue",
- *   options={"collate"="utf8_swedish_ci"},
+ *   options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4"},
  *   indexes={
  *     @ORM\Index(name="execute_at_idx", columns={"execute_at"}),
  *     @ORM\Index(name="status_idx",     columns={"status"}),

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Table(
  *   name="task_schedules",
- *   options={"collate"="utf8_swedish_ci"},
+ *   options={"collate"="utf8mb4_unicode_ci", "charset"="utf8mb4"},
  *   indexes={
  *     @ORM\Index(name="active_idx", columns={"active"})
  *   }


### PR DESCRIPTION
# Description

This PR aims to resolve the following problematics.

## Doctrine Charset

If the Doctrine charset defined in the project configuration is not equal to `utf8` it become impossible for Doctrine to create the schema as it try to create the table with incompatible charset and collation.

For example if your project is configured like this :
```yaml
doctrine:
    dbal:
        charset: utf8mb4
        default_table_options:
          charset: utf8mb4
          collate: utf8mb4_unicode_ci
```
(...) running the `bin/console doctrine:schema:create` command will result in the following error :

```sql
SQLSTATE[42000]: Syntax error or access violation: 1253 COLLATION 'utf8_swedish_ci' is not valid for CHARACTER SET 'utf8mb4'' while executing DDL:
```

Setting the charset explicitly and accordingly with the collation in the table definition will fixi this issue.

```php
/**
 * @ORM\Table(
 *   name="task_queue",
 *   options={"collate"="utf8_swedish_ci", "charset"="utf8"},
 * ...
 */
```

## Alphabet limitations

As we are working on this part, I recommend to change the collation `swedish` to the more standardized one `unicode` using the `utf8mb4` charset to support Asian and more foreign alphabets.